### PR TITLE
rails5.2.8へアップグレード時に発生したcannot load such file -- i18n/core_ext/hash（LoadError）の対応

### DIFF
--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-require 'i18n/core_ext/hash'
+require 'active_support/core_ext/hash'
 require 'yaml'
 require 'erb'
 


### PR DESCRIPTION
# 内容

■変更内容
lib/cequel/record/railtie.rbの2行目のrequire 'i18n/core_ext/hash'をrequire 'active_support/core_ext/hash'に変更。

■修正前に発生していたエラー
Railsのバージョンを5.2.8に上げた際に発生。
エラーメッセージ：cannot load such file -- i18n/core_ext/hash

■関連issue
https://github.com/ruby-i18n/i18n/issues/603