### PR TITLE
refactor: Rails7.0に対応

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -64,42 +64,15 @@ namespace :cequel do
   end
 
   def migrate
-    watch_stack = ActiveSupport::Dependencies::WatchStack.new
-
     migration_table_names = Set[]
-    project_root = defined?(Rails) ? Rails.root : Dir.pwd
-    models_dir_path = "#{File.expand_path('app/models', project_root)}/"
-    model_files = Dir.glob(File.join(models_dir_path, '**', '*.rb'))
-    model_files.sort.each do |file|
-      watch_namespaces = ["Object"]
-      model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")
-      dirname = File.dirname(model_file_name)
-      watch_namespaces << dirname.classify unless dirname == "."
-      watch_stack.watch_namespaces(watch_namespaces)
-      require_dependency(file)
+    Rails.application.eager_load!
+    ObjectSpace.each_object(Class) do |clazz|
+      next unless clazz.ancestors.include?(Cequel::Record)
+      next if migration_table_names.include?(clazz.table_name.to_sym)
 
-      new_constants = watch_stack.new_constants
-      if new_constants.empty?
-        new_constants << model_file_name.sub(/\.rb$/, "").classify
-      end
-
-      new_constants.each do |class_name|
-        # rubocop:disable HandleExceptions
-        begin
-          clazz = class_name.constantize
-        rescue LoadError, NameError, RuntimeError
-        else
-          if clazz.is_a?(Class)
-            if clazz.ancestors.include?(Cequel::Record) &&
-                !migration_table_names.include?(clazz.table_name.to_sym)
-              clazz.synchronize_schema
-              migration_table_names << clazz.table_name.to_sym
-              puts "Synchronized schema for #{class_name}"
-            end
-          end
-        end
-        # rubocop:enable HandleExceptions
-      end
+      clazz.synchronize_schema
+      migration_table_names << clazz.table_name.to_sym
+      puts "Synchronized schema for #{clazz.name}"
     end
   end
 end


### PR DESCRIPTION
# 変更内容
Rails7.0に対応させるためmigrateメソッドで`ActiveSupport::Dependencies::WatchStack`を使わないように修正

# 変更理由
Rails7で classic オートローダーが削除され、`ActiveSupport::Dependencies::WatchStack`および関連APIが削除され、cequal:migrateが失敗するため

https://github.com/naviplus-asp/falcie/actions/runs/22819648787/job/66190293530?pr=3080
```
...
rake aborted!
NameError: uninitialized constant ActiveSupport::Dependencies::WatchStack
/home/runner/work/falcie/falcie/vendor/bundle/ruby/3.0.0/bundler/gems/cequel-for-falcie-c800e036e8ad/lib/cequel/record/tasks.rb:67:in `migrate'
/home/runner/work/falcie/falcie/vendor/bundle/ruby/3.0.0/bundler/gems/cequel-for-falcie-c800e036e8ad/lib/cequel/record/tasks.rb:39:in `block (2 levels) in <top (required)>'
```

# 動作確認手順
関連PRのCIチェックが通っていること

# 関連PR
https://github.com/naviplus-asp/falcie/pull/3080

# 仕様書


# 備考
