### PR TITLE
refactor: Ruby3.1に対応させる

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 language: ruby
 
 rvm:
-  - "3.0"
+  - "3.1"
 
 gemfile:
   - "gemfiles/rails_6.1.gemfile"

--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -24,7 +24,7 @@ DESC
 
   s.files = Dir['lib/**/*.rb', 'templates/**/*', 'spec/**/*.rb', '[A-Z]*']
   s.test_files = Dir['spec/examples/**/*.rb']
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency 'activemodel', '>= 4.0'
   s.add_runtime_dependency 'cassandra-driver', '~> 3.0'

--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -52,7 +52,7 @@ module Cequel
 
         if File.exist?(config_path)
           config_yaml = ERB.new(File.read(config_path)).result
-          @configuration = YAML.load(config_yaml)[Rails.env]
+          @configuration = YAML.safe_load(config_yaml, aliases: true)[Rails.env]
             .deep_symbolize_keys
         else
           @configuration = {host: '127.0.0.1:9042'}

--- a/spec/examples/record/railtie_spec.rb
+++ b/spec/examples/record/railtie_spec.rb
@@ -1,0 +1,74 @@
+# -*- encoding : utf-8 -*-
+require_relative 'spec_helper'
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+
+unless defined?(Rails)
+  module Rails
+    class << self
+      attr_accessor :env, :root
+    end
+
+    class Railtie
+      class << self
+        def config
+          @config ||= Struct.new(:cequel).new
+        end
+
+        def initializer(*)
+        end
+
+        def rake_tasks(*)
+        end
+
+        def generators(*)
+        end
+      end
+    end
+  end
+end
+
+require_relative '../../../lib/cequel/record/railtie'
+
+describe Cequel::Record::Railtie do
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      @tmpdir = tmpdir
+      example.run
+    end
+  end
+
+  before do
+    allow(Rails).to receive(:env).and_return('development')
+    allow(Rails).to receive(:root).and_return(Pathname.new(@tmpdir))
+    allow(described_class).to receive(:app_name).and_return('falcie')
+  end
+
+  describe '#configuration' do
+    it 'loads yaml aliases from cequel.yml' do
+      FileUtils.mkdir_p(File.join(@tmpdir, 'config'))
+      File.write(File.join(@tmpdir, 'config/cequel.yml'), <<~YAML)
+        default: &default
+          host: '127.0.0.1'
+          port: 9042
+          max_retries: 3
+          retry_delay: 0.5
+          newrelic: false
+
+        development:
+          <<: *default
+          keyspace: falcie_development
+      YAML
+
+      expect(described_class.new.send(:configuration)).to eq(
+        host: '127.0.0.1',
+        port: 9042,
+        max_retries: 3,
+        retry_delay: 0.5,
+        newrelic: false,
+        keyspace: 'falcie_development'
+      )
+    end
+  end
+end


### PR DESCRIPTION
# 変更内容
Ruby3.1にバンドルされているPsych 4に合わせた変更を加えました。

# 変更理由
Ruby3.1に対応させるため

# 確認方法
コードのみの確認でOKです。
関連PRでの確認が通っていればOK

# 関連PR
https://github.com/naviplus-asp/falcie/pull/3092